### PR TITLE
Threading Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Maven
 <dependency>
     <groupId>com.ssplugins.rlstats</groupId>
     <artifactId>RLStatsAPI</artifactId>
-    <version>1.0.1-beta</version>
+    <version>1.1.0-beta</version>
 </dependency>
 ```
 
@@ -34,8 +34,6 @@ Usage
 You will need an API key for RocketLeagueStats in order to use the API.  
 API keys are available at the [Developer Portal](https://developers.rocketleaguestats.com/).
   
-**Important:** Your application should take care to call [RLStatsAPI#shutdownThreads()](http://ssplugins.com/docs/java/RLStatsAPI/com/ssplugins/rlstats/RLStatsAPI.html#shutdownThreads--) when it it done using an instance of the API (i.e. about to close) or the application may not shutdown correctly.
-
 Example getting player info.
 ```java
 import com.ssplugins.rlstats.entities.Platform;
@@ -60,10 +58,6 @@ public class GetStats {
 		PlaylistInfo info = player.getSeasonInfo(5).getPlaylistInfo(Playlist.RANKED_DOUBLES);
 		int tier = info.getTier();
 		int division = info.getDivision();
-		
-		// Should be called when you are finished using the API with this instance.
-		// If not called your application may not shutdown correctly.
-		api.shutdownThreads();
 	}
 	
 	public void foo(RLStatsAPI api) {

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Maven
 <dependency>
     <groupId>com.ssplugins.rlstats</groupId>
     <artifactId>RLStatsAPI</artifactId>
-    <version>1.1.0-beta</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 

--- a/src/main/java/com/ssplugins/rlstats/IRLStatsAPI.java
+++ b/src/main/java/com/ssplugins/rlstats/IRLStatsAPI.java
@@ -24,13 +24,12 @@ public class IRLStatsAPI implements RLStatsAPI {
 	
 	private final ExecutorService tasks = ForkJoinPool.commonPool();
 	
-	private RequestQueue queue = new RequestQueue(this);
-	
 	private String key = null;
 	private String apiVersion = "v1";
 	private int requestsPerSecond = 2;
-	
 	private Consumer<Exception> exceptionHandler;
+	
+	private RequestQueue queue = new RequestQueue(this);
 	
 	IRLStatsAPI() {}
 	

--- a/src/main/java/com/ssplugins/rlstats/RLStatsAPI.java
+++ b/src/main/java/com/ssplugins/rlstats/RLStatsAPI.java
@@ -19,6 +19,14 @@ public interface RLStatsAPI {
 	void setExceptionHandler(Consumer<Exception> exceptionHandler);
 	
 	/**
+	 * Set the number of requests this API should assume your rlstats api key has. (Default 2)
+	 * If this is set higher than the amount your account has, an exception may be thrown
+	 * for too many requests being sent.
+	 * @param i Requests per second.
+	 */
+	void setRequestsPerSecond(int i);
+	
+	/**
 	 * Sets the auth key used for API requests.
 	 * @param key The key to use for API requests.
 	 */

--- a/src/main/java/com/ssplugins/rlstats/RLStatsAPI.java
+++ b/src/main/java/com/ssplugins/rlstats/RLStatsAPI.java
@@ -7,14 +7,16 @@ import com.ssplugins.rlstats.util.PlayerRequest;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Future;
+import java.util.function.Consumer;
 
 public interface RLStatsAPI {
 	
 	/**
-	 * Shuts down the executors to properly close the threads.
-	 * Once called, a new instance must be created to access the API.
+	 * Sets the {@link Consumer} that will be called when an exception is thrown.
+	 * Exceptions due to invalid parameters are thrown as normal and not sent here.
+	 * @param exceptionHandler {@link Consumer} to handle exceptions.
 	 */
-	void shutdownThreads();
+	void setExceptionHandler(Consumer<Exception> exceptionHandler);
 	
 	/**
 	 * Sets the auth key used for API requests.

--- a/src/main/java/com/ssplugins/rlstats/RLStatsAPI.java
+++ b/src/main/java/com/ssplugins/rlstats/RLStatsAPI.java
@@ -1,7 +1,6 @@
 package com.ssplugins.rlstats;
 
 import com.ssplugins.rlstats.entities.*;
-import com.ssplugins.rlstats.entities.Stat;
 import com.ssplugins.rlstats.util.PlayerRequest;
 
 import java.util.Collection;

--- a/src/main/java/com/ssplugins/rlstats/util/RequestQueue.java
+++ b/src/main/java/com/ssplugins/rlstats/util/RequestQueue.java
@@ -9,22 +9,40 @@ import com.mashape.unirest.request.HttpRequestWithBody;
 import com.ssplugins.rlstats.IRLStatsAPI;
 import com.ssplugins.rlstats.RLStats;
 
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
 
 public class RequestQueue {
 	
-	private final ForkJoinPool service = ForkJoinPool.commonPool();
+	private final ExecutorService service = ForkJoinPool.commonPool();
 	
 	private IRLStatsAPI api;
 	
-	private int requestsLeft;
-	private long msRemaining, lastRequest;
+	private BlockingQueue<Integer> queue = new LinkedBlockingQueue<>();
+	private AtomicBoolean waiting = new AtomicBoolean();
 	
 	public RequestQueue(IRLStatsAPI api) {
 		this.api = api;
-		this.requestsLeft = 2;
-		this.msRemaining = -1;
+		addRequests(api.getRequestsPerSecond());
+	}
+	
+	private void addRequests(int i) {
+		IntStream.range(0, i).forEach(queue::add);
+	}
+	
+	private void waitForRequests(long msRemaining) {
+		if (waiting.get()) return;
+		waiting.set(true);
+		service.submit(() -> {
+			try {
+				Thread.sleep(msRemaining);
+			} catch (InterruptedException e) {
+				api.exception(e);
+			}
+			waiting.set(false);
+			addRequests(api.getRequestsPerSecond());
+		});
 	}
 	
 	public Future<JsonNode> post(String apiKey, String apiVersion, String endpoint, Query query, String body) {
@@ -38,17 +56,7 @@ public class RequestQueue {
 	private Future<JsonNode> request(String apiKey, String apiVersion, String endpoint, Query query, String body, boolean post) {
 		String url = RLStats.BASE_URL + apiVersion + endpoint + (query == null ? "" : query.toString());
 		return service.submit(() -> {
-			if (requestsLeft == 0) {
-				long time = System.currentTimeMillis();
-				long delta = time - lastRequest;
-				if (delta < msRemaining) {
-					try {
-						Thread.sleep(msRemaining - delta);
-					} catch (InterruptedException e) {
-						api.exception(e);
-					}
-				}
-			}
+			queue.take(); // Wait until there are requests available.
 			try {
 				Unirest.setTimeouts(RLStats.CONNECTION_TIMEOUT, RLStats.SOCKET_TIMEOUT);
 				HttpResponse<JsonNode> response;
@@ -62,9 +70,7 @@ public class RequestQueue {
 				}
 				checkStatus(response);
 				Headers headers = response.getHeaders();
-				requestsLeft = Integer.parseInt(headers.getFirst("X-Rate-Limit-Remaining"));
-				msRemaining = Long.parseLong(headers.getFirst("X-Rate-Limit-Reset-Remaining"));
-				lastRequest = System.currentTimeMillis();
+				waitForRequests(Long.parseLong(headers.getFirst("X-Rate-Limit-Reset-Remaining")));
 				return response.getBody();
 			} catch (UnirestException | IllegalStateException e) {
 				api.exception(e);
@@ -89,7 +95,7 @@ public class RequestQueue {
 			case 406:
 				throw new IllegalStateException("Not Acceptable. Requested format that isn't json. (E:406)");
 			case 429:
-				throw new IllegalStateException("Too Many Requests. Retry after " + response.getHeaders().getFirst("retry-after-ms") + "ms (E:429)");
+				throw new IllegalStateException("Too Many Requests. Retry after " + response.getHeaders().getFirst("Retry-After-Ms") + "ms (E:429)");
 			case 500:
 				throw new IllegalStateException("Internal Server Error. (E:500) Message: " + response.getBody().getObject().getString("message"));
 			case 503:


### PR DESCRIPTION
- Cached thread pool and single thread executor have been replaced with ForkJoinPool.
- RLStatsAPI#shutdownThreads() has been removed. The ForkJoinPool automatically takes care of shutting down threads when program exits.
- Exceptions are not printed by default anymore. You can use RLStatsAPI#setExceptionHandler(Consumer<Exception>) to set what happens when an exception is thrown. Exception that occur due to invalid parameters are still thrown as normal.