### PR TITLE
Small fix

### DIFF
--- a/src/main/java/com/ssplugins/rlstats/util/RequestQueue.java
+++ b/src/main/java/com/ssplugins/rlstats/util/RequestQueue.java
@@ -41,7 +41,7 @@ public class RequestQueue {
 				api.exception(e);
 			}
 			waiting.set(false);
-			addRequests(api.getRequestsPerSecond());
+			addRequests(api.getRequestsPerSecond() - queue.size());
 		});
 	}
 	


### PR DESCRIPTION
There was one line that had an incorrect value.
It could cause the library to allow more requests than your api key has.